### PR TITLE
pages should have different scores for different sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for carbon-tracker
 
+## 4.1.0 - 2024-03-08
+### Added
+- Added multisite support ([#3](https://github.com/statikbe/craft-carbon-tracker/issues/3))
+
 ## 4.0.3 - 2024-01-12
 ### Fixed
 - Fix typo in sidebar template
@@ -7,7 +11,6 @@
 ## 4.0.2 - 2024-01-05
 ### Fixed
 - Only run our job for enabled entries, because we need to be able to crawl them.
-
 
 ## 4.0.1 - 2024-01-04
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "statikbe/craft-carbon-tracker",
     "description": "Carbon tracker aims to raise awareness of the carbon emissions created by webpages, by displaying these insights along side the content in Craft's control panel.",
     "type": "craft-plugin",
-    "version": "4.0.3",
+    "version": "4.1.0",
     "license": "mit",
     "support": {
         "email": "support@statik.be",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "scripts": {
         "check-cs": "ecs check --ansi",
         "fix-cs": "ecs check --ansi --fix",
-        "phpstan": "phpstan --memory-limit=1G"
+        "phpstan": "phpstan --memory-limit=1G",
+        "ci": "ecs check --ansi --fix && phpstan --memory-limit=1G"
     },
     "config": {
         "sort-packages": true,

--- a/src/CarbonTracker.php
+++ b/src/CarbonTracker.php
@@ -31,7 +31,7 @@ use yii\console\Application as ConsoleApplication;
  */
 class CarbonTracker extends Plugin
 {
-    public string $schemaVersion = '1.0.0';
+    public string $schemaVersion = '1.1.0';
     public bool $hasCpSettings = true;
 
     /**
@@ -80,7 +80,7 @@ class CarbonTracker extends Plugin
             function(ModelEvent $event) {
                 /** @var Entry $entry */
                 $entry = $event->sender;
-                if (!ElementHelper::isDraftOrRevision($entry) && $entry->getUrl()) {
+                if (!ElementHelper::isDraftOrRevision($entry) && $entry->getUrl() && !$entry->propagating) {
                     Queue::push(new CarbonStatsJob([
                         'entryId' => $entry->id,
                         'siteId' => $entry->siteId,

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -15,6 +15,7 @@ class Install extends Migration
             [
                 'id' => $this->primaryKey(),
                 'entryId' => $this->integer()->notNull(),
+                'siteId' => $this->integer()->notNull(),
                 'url' => $this->string()->notNull(),
                 'green' => $this->boolean()->defaultValue(0),
                 'bytes' => $this->integer(),

--- a/src/migrations/m240307_121231_addSiteIdCol.php
+++ b/src/migrations/m240307_121231_addSiteIdCol.php
@@ -2,7 +2,6 @@
 
 namespace statikbe\carbontracker\migrations;
 
-use Craft;
 use craft\db\Migration;
 use statikbe\carbontracker\records\SiteStatisticsRecord;
 

--- a/src/migrations/m240307_121231_addSiteIdCol.php
+++ b/src/migrations/m240307_121231_addSiteIdCol.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace statikbe\carbontracker\migrations;
+
+use Craft;
+use craft\db\Migration;
+use statikbe\carbontracker\records\SiteStatisticsRecord;
+
+/**
+ * m240307_121231_addSiteIdCol migration.
+ */
+class m240307_121231_addSiteIdCol extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->addColumn(
+            SiteStatisticsRecord::tableName(),
+            'siteId',
+            $this->integer()->notNull()->after('entryId')
+        );
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240307_121231_addSiteIdCol cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/SiteStatisticsModel.php
+++ b/src/models/SiteStatisticsModel.php
@@ -10,6 +10,7 @@ use craft\base\Model;
 class SiteStatisticsModel extends Model
 {
     public int $entryId;
+    public int $siteId;
     public string $url = "https://";
     public bool $green = false;
     public int $bytes = 0;
@@ -23,8 +24,8 @@ class SiteStatisticsModel extends Model
     public function rules(): array
     {
         return [
-            [['entryId', 'url', 'green', 'bytes', 'cleanerThan', 'rating', 'dateUpdated'], 'required'],
-            [['entryId', 'url', 'green', 'bytes', 'cleanerThan', 'rating', 'dateUpdated'], 'safe'],
+            [['entryId', 'siteId', 'url', 'green', 'bytes', 'cleanerThan', 'rating', 'dateUpdated'], 'required'],
+            [['entryId', 'siteId', 'url', 'green', 'bytes', 'cleanerThan', 'rating', 'dateUpdated'], 'safe'],
         ];
     }
 }

--- a/src/records/SiteStatisticsRecord.php
+++ b/src/records/SiteStatisticsRecord.php
@@ -6,6 +6,7 @@ use craft\db\ActiveRecord;
 
 /**
  * @property int $entryId entryId
+ * @property int $siteId siteId
  * @property string $url url
  * @property boolean $green green
  * @property float $cleanerThan cleanerThan

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -28,37 +28,62 @@ class ApiService extends Component
         $model = new SiteStatisticsModel();
 
         if (getenv('CRAFT_ENVIRONMENT') === 'dev') {
-            $url = self::READ_MORE_LINK;
+            $json_data = '{
+                "url": "https://www.wholegraindigital.com/",
+                "green": true,
+                "rating": "A+",
+                "bytes": 443854,
+                "cleanerThan": 0.83,
+                "statistics": {
+                    "adjustedBytes": 335109.77,
+                    "energy": 0.0005633320052642376,
+                    "co2": {
+                        "grid": {
+                            "grams": 0.26758270250051286,
+                            "litres": 0.14882949913078525
+                        },
+                        "renewable": {
+                            "grams": 0.24250694721722435,
+                            "litres": 0.13488236404222018
+                        }
+                    }
+                }
+            }';
+
+            $data = json_decode($json_data, true);
         } else {
-            $url = $entry->getUrl();
-        }
 
-        try {
-            $data = $this->makeRequest('/site', [
-                'query' => [
-                    'url' => $url,
-                ],
-            ]);
 
-            if (empty($data)) {
-                return $model;
+            try {
+
+                $url = $entry->getUrl();
+                $data = $this->makeRequest('/site', [
+                    'query' => [
+                        'url' => $url,
+                    ],
+                ]);
+            } catch (\Exception $e) {
+                \Craft::error($e->getMessage(), CarbonTracker::class);
+                return false;
             }
-
-            $model->setAttributes([
-                'entryId' => $entry->id,
-                'siteId' => $entry->siteId,
-                'url' => $data['url'],
-                'green' => $data['green'],
-                'bytes' => $data['bytes'],
-                'cleanerThan' => $data['cleanerThan'],
-                'rating' => $data['rating'],
-            ]);
-
-            return $model;
-        } catch (\Exception $e) {
-            \Craft::error($e->getMessage(), CarbonTracker::class);
-            return false;
         }
+
+
+        if (empty($data)) {
+            return $model;
+        }
+
+        $model->setAttributes([
+            'entryId' => $entry->id,
+            'siteId' => $entry->siteId,
+            'url' => $data['url'],
+            'green' => $data['green'],
+            'bytes' => $data['bytes'],
+            'cleanerThan' => $data['cleanerThan'],
+            'rating' => $data['rating'],
+        ]);
+
+        return $model;
     }
 
     /**

--- a/src/services/ApiService.php
+++ b/src/services/ApiService.php
@@ -52,10 +52,7 @@ class ApiService extends Component
 
             $data = json_decode($json_data, true);
         } else {
-
-
             try {
-
                 $url = $entry->getUrl();
                 $data = $this->makeRequest('/site', [
                     'query' => [

--- a/src/services/StatsService.php
+++ b/src/services/StatsService.php
@@ -13,11 +13,14 @@ class StatsService extends Component
 {
     public function getDataForEntry(Entry $entry): SiteStatisticsModel|bool
     {
-        $record = SiteStatisticsRecord::findOne(['entryId' => $entry->id]);
-
+        $record = SiteStatisticsRecord::findOne(['entryId' => $entry->id, 'siteId' => $entry->siteId]);
+        
         if (!$record) {
-            // What if we don't have any data yet?
-            return false;
+            // Search again without the siteId
+            $record = SiteStatisticsRecord::findOne(['entryId' => $entry->id]);
+            if(!$record) {
+                return false;
+            }
         }
 
         $model = new SiteStatisticsModel();

--- a/src/services/StatsService.php
+++ b/src/services/StatsService.php
@@ -18,7 +18,7 @@ class StatsService extends Component
         if (!$record) {
             // Search again without the siteId
             $record = SiteStatisticsRecord::findOne(['entryId' => $entry->id]);
-            if(!$record) {
+            if (!$record) {
                 return false;
             }
         }

--- a/src/services/StatsService.php
+++ b/src/services/StatsService.php
@@ -31,6 +31,7 @@ class StatsService extends Component
         $date = DateTimeHelper::currentUTCDateTime()->modify('-1 day');
         $record = SiteStatisticsRecord::find()
             ->where(['=', 'entryId', $entry->id])
+            ->andWhere(['=', 'siteId', $entry->siteId])
             ->andWhere(['>=', 'dateCreated', $date->format('c')])
             ->one();
 
@@ -41,12 +42,15 @@ class StatsService extends Component
         }
 
         $stats = CarbonTracker::getInstance()->api->getSite($entry);
-        $record = new SiteStatisticsRecord();
-        $record->entryId = $stats->entryId;
-        $record->url = $stats->url;
-        $record->green = $stats->green;
-        $record->cleanerThan = $stats->cleanerThan;
-        $record->rating = $stats->rating;
-        $record->save();
+        if ($stats) {
+            $record = new SiteStatisticsRecord();
+            $record->entryId = $stats->entryId;
+            $record->siteId = $stats->siteId;
+            $record->url = $stats->url;
+            $record->green = $stats->green;
+            $record->cleanerThan = $stats->cleanerThan;
+            $record->rating = $stats->rating;
+            $record->save();
+        }
     }
 }


### PR DESCRIPTION
### Description
We were only saving 1 score for each entry, independent of which site it was saved from

### Reason for this change
With this change we track the site along with the entry, so that entries can have different scores per site.