### PR TITLE
Use boolean in install migration

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -17,7 +17,7 @@ class Install extends Migration
                 'entryId' => $this->integer()->notNull(),
                 'siteId' => $this->integer()->notNull(),
                 'url' => $this->string()->notNull(),
-                'green' => $this->boolean()->defaultValue(0),
+                'green' => $this->boolean()->defaultValue(false),
                 'bytes' => $this->integer(),
                 'cleanerThan' => $this->float()->defaultValue(0.0),
                 'rating' => $this->string(2),


### PR DESCRIPTION
Should fix an installation error that's happening for PostgreSQL users, as reported in #8.